### PR TITLE
Create utility methods to replace static method

### DIFF
--- a/MonoBrickFirmwareWrapper/MonoBrickFirmwareWrapper.csproj
+++ b/MonoBrickFirmwareWrapper/MonoBrickFirmwareWrapper.csproj
@@ -37,6 +37,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Movement\IMotor.cs" />
     <Compile Include="UserInput\ButtonsWrapper.cs" />
+    <Compile Include="Utilities\Replacer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\monoev3\MonoBrickFirmware\MonoBrickFirmware.csproj">

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -28,6 +28,16 @@ namespace MonoBrickFirmwareWrapper.Utilities
         {
         }
 
+        /// <summary>
+        /// <para>Restore the original value of a private static field of a specified class.</para>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the field value hasn't been replaced or has been restored, this method do nothing.
+        /// </para>
+        /// </remarks>
+        /// <param name="targetClassType">The type of a class including a target private static field.</param>
+        /// <param name="fieldName">A target private static field name.</param>
         public static void RestorePrivateStaticField(Type targetClassType, string fieldName)
         {
         }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -20,6 +20,11 @@ namespace MonoBrickFirmwareWrapper.Utilities
         /// </summary>
         private static IDictionary<string, object> originalFieldValues = new Dictionary<string, object>();
 
+        private static string createKey(Type targetClassType, string fieldName)
+        {
+            return $"{targetClassType}+{fieldName}";
+        }
+
         /// <summary>
         /// <para>Replace a private static field value of a specified class.</para>
         /// <para>
@@ -39,7 +44,7 @@ namespace MonoBrickFirmwareWrapper.Utilities
         /// </exception>
         public static void ReplacePrivateStaticField<T>(Type targetClassType, string fieldName, T fieldValue)
         {
-            string key = $"{targetClassType}+{fieldName}";
+            string key = createKey(targetClassType, fieldName);
 
             FieldInfo fieldInfo = targetClassType.GetField(fieldName,
                 BindingFlags.GetField | BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);
@@ -60,7 +65,7 @@ namespace MonoBrickFirmwareWrapper.Utilities
         /// <param name="fieldName">A target private static field name.</param>
         public static void RestorePrivateStaticField(Type targetClassType, string fieldName)
         {
-            string key = $"{targetClassType}+{fieldName}";
+            string key = createKey(targetClassType, fieldName);
 
             FieldInfo fieldInfo = targetClassType.GetField(fieldName,
                 BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -10,6 +10,8 @@ namespace MonoBrickFirmwareWrapper.Utilities
     /// </summary>
     public static class Replacer
     {
+        private static IDictionary<string, object> originalFieldValues = new Dictionary<string, object>();
+
         /// <summary>
         /// <para>Replace a private static field value of a specified class.</para>
         /// <para>

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -61,6 +61,10 @@ namespace MonoBrickFirmwareWrapper.Utilities
         public static void RestorePrivateStaticField(Type targetClassType, string fieldName)
         {
             string key = $"{targetClassType}+{fieldName}";
+
+            FieldInfo fieldInfo = targetClassType.GetField(fieldName,
+                BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);
+            fieldInfo.SetValue(null, originalFieldValues[key]);
         }
     }
 }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -65,6 +65,8 @@ namespace MonoBrickFirmwareWrapper.Utilities
             FieldInfo fieldInfo = targetClassType.GetField(fieldName,
                 BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);
             fieldInfo.SetValue(null, originalFieldValues[key]);
+
+            originalFieldValues.Remove(key);
         }
     }
 }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -10,5 +10,9 @@ namespace MonoBrickFirmwareWrapper.Utilities
         public static void ReplacePrivateStaticField<T>(Type targetClassType, string fieldName, T fieldValue)
         {
         }
+
+        public static void RestorePrivateStaticField(Type targetClassType, string fieldName)
+        {
+        }
     }
 }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -7,5 +7,8 @@ namespace MonoBrickFirmwareWrapper.Utilities
 {
     public static class Replacer
     {
+        public static void ReplacePrivateStaticField<T>(Type targetClassType, string fieldName, T fieldValue)
+        {
+        }
     }
 }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Linq;
 using System.Text;
 

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace MonoBrickFirmwareWrapper.Utilities
 {
-    static class Replacer
+    public static class Replacer
     {
     }
 }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Linq;
-using System.Text;
 
 namespace MonoBrickFirmwareWrapper.Utilities
 {

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -42,7 +42,9 @@ namespace MonoBrickFirmwareWrapper.Utilities
             string key = $"{targetClassType}+{fieldName}";
 
             FieldInfo fieldInfo = targetClassType.GetField(fieldName,
-                BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);
+                BindingFlags.GetField | BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);
+
+            originalFieldValues.Add(key, fieldInfo.GetValue(null));
             fieldInfo.SetValue(null, fieldValue);
         }
 

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -7,6 +7,23 @@ namespace MonoBrickFirmwareWrapper.Utilities
 {
     public static class Replacer
     {
+        /// <summary>
+        /// <para>Replace a private static field value of a specified class.</para>
+        /// <para>
+        /// NOTICE: Restore the original value of the target field
+        /// using <see cref="RestorePrivateStaticField(Type, string)"/>
+        /// by the end of each test case,
+        /// because the static field value may influence other test cases.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">The type of a target private static field.</typeparam>
+        /// <param name="targetClassType">The type of a class including a target private static field.</param>
+        /// <param name="fieldName">A target private static field name.</param>
+        /// <param name="fieldValue">A value that you want to replace with.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The target field has already replaced.
+        /// You can't replace with another value until you restore the original value.
+        /// </exception>
         public static void ReplacePrivateStaticField<T>(Type targetClassType, string fieldName, T fieldValue)
         {
         }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -51,6 +51,8 @@ namespace MonoBrickFirmwareWrapper.Utilities
         public static void ReplacePrivateStaticField<T>(Type targetClassType, string fieldName, T fieldValue)
         {
             string key = createKey(targetClassType, fieldName);
+            
+            if (originalFieldValues.ContainsKey(key)) { throw new InvalidOperationException(); }
 
             FieldInfo fieldInfo = targetClassType.GetField(fieldName,
                 BindingFlags.GetField | BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -5,6 +5,9 @@ using System.Text;
 
 namespace MonoBrickFirmwareWrapper.Utilities
 {
+    /// <summary>
+    /// An utility class to replace static fields of MonoBrickFirmwareWrapper.
+    /// </summary>
     public static class Replacer
     {
         /// <summary>

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -28,7 +28,7 @@ namespace MonoBrickFirmwareWrapper.Utilities
         /// <returns>a key of a specified field.</returns>
         private static string createKey(Type targetClassType, string fieldName)
         {
-            return $"{targetClassType}+{fieldName}";
+            return targetClassType + "+" + fieldName;
         }
 
         /// <summary>

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -83,5 +83,175 @@ namespace MonoBrickFirmwareWrapper.Utilities
 
             originalFieldValues.Remove(key);
         }
+
+        public static void ReplaceWrapperMethod(Type targetClassType, string methodName, Action action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T>(Type targetClassType, string methodName, Action<T> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2>(Type targetClassType, string methodName, Action<T1, T2> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3>(Type targetClassType, string methodName, Action<T1, T2, T3> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4>(Type targetClassType, string methodName, Action<T1, T2, T3, T4> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, action);
+        }
+
+        public static void ReplaceWrapperMethod<TResult>(Type targetClassType, string methodName, Func<TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T, TResult>(Type targetClassType, string methodName, Func<T, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, TResult>(Type targetClassType, string methodName, Func<T1, T2, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
+
+        public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> function)
+        {
+            ReplacePrivateStaticField(targetClassType, methodName, function);
+        }
     }
 }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace MonoBrickFirmwareWrapper.Utilities
 {
-    class Replacer
+    static class Replacer
     {
     }
 }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -10,6 +10,13 @@ namespace MonoBrickFirmwareWrapper.Utilities
     /// </summary>
     public static class Replacer
     {
+        /// <summary>
+        /// <para>An dictionary to store original values.</para>
+        /// <para>
+        /// The key is the field name with full qualifier name of class.
+        /// The value is the original value.
+        /// </para>
+        /// </summary>
         private static IDictionary<string, object> originalFieldValues = new Dictionary<string, object>();
 
         /// <summary>

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -39,6 +39,8 @@ namespace MonoBrickFirmwareWrapper.Utilities
         /// </exception>
         public static void ReplacePrivateStaticField<T>(Type targetClassType, string fieldName, T fieldValue)
         {
+            string key = $"{targetClassType}+{fieldName}";
+
             FieldInfo fieldInfo = targetClassType.GetField(fieldName,
                 BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);
             fieldInfo.SetValue(null, fieldValue);

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -84,171 +84,664 @@ namespace MonoBrickFirmwareWrapper.Utilities
             originalFieldValues.Remove(key);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod(Type targetClassType, string methodName, Action action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T">The type of 1st argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T>(Type targetClassType, string methodName, Action<T> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of 2nd argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2>(Type targetClassType, string methodName, Action<T1, T2> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3>(Type targetClassType, string methodName, Action<T1, T2, T3> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4>(Type targetClassType, string methodName, Action<T1, T2, T3, T4> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T15">The type of the 15th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T15">The type of the 15th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T16">The type of the 16th argument of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Type targetClassType, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action)
         {
             ReplacePrivateStaticField(targetClassType, methodName, action);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<TResult>(Type targetClassType, string methodName, Func<TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T, TResult>(Type targetClassType, string methodName, Func<T, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, TResult>(Type targetClassType, string methodName, Func<T1, T2, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T15">The type of the 15th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+        /// <summary>
+        /// Replace a wrapper method of MonoBrickFirmwareWrapper.
+        /// </summary>
+        /// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+        /// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+        /// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T15">The type of the 15th argument of the wrapper method.</typeparam>
+        /// <typeparam name="T16">The type of the 16th argument of the wrapper method.</typeparam>
+        /// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+        /// <param name="targetClassType">The type of a class including a wrapper method.</param>
+        /// <param name="methodName">A wrapper method name.</param>
+        /// <param name="action">An action that you want to replace with.</param>
         public static void ReplaceWrapperMethod<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Type targetClassType, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> function)
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -75,6 +75,8 @@ namespace MonoBrickFirmwareWrapper.Utilities
         {
             string key = createKey(targetClassType, fieldName);
 
+            if (!originalFieldValues.ContainsKey(key)) { return; }
+
             FieldInfo fieldInfo = targetClassType.GetField(fieldName,
                 BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);
             fieldInfo.SetValue(null, originalFieldValues[key]);

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MonoBrickFirmwareWrapper.Utilities
+{
+    class Replacer
+    {
+    }
+}

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -39,6 +39,9 @@ namespace MonoBrickFirmwareWrapper.Utilities
         /// </exception>
         public static void ReplacePrivateStaticField<T>(Type targetClassType, string fieldName, T fieldValue)
         {
+            FieldInfo fieldInfo = targetClassType.GetField(fieldName,
+                BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Static);
+            fieldInfo.SetValue(null, fieldValue);
         }
 
         /// <summary>

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -20,6 +20,12 @@ namespace MonoBrickFirmwareWrapper.Utilities
         /// </summary>
         private static IDictionary<string, object> originalFieldValues = new Dictionary<string, object>();
 
+        /// <summary>a
+        /// Create a key of a specified field for the original value dictionary.
+        /// </summary>
+        /// <param name="targetClassType">The type of a class including a target private static field.</param>
+        /// <param name="fieldName">A target private static field name.</param>
+        /// <returns>a key of a specified field.</returns>
         private static string createKey(Type targetClassType, string fieldName)
         {
             return $"{targetClassType}+{fieldName}";

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -60,6 +60,7 @@ namespace MonoBrickFirmwareWrapper.Utilities
         /// <param name="fieldName">A target private static field name.</param>
         public static void RestorePrivateStaticField(Type targetClassType, string fieldName)
         {
+            string key = $"{targetClassType}+{fieldName}";
         }
     }
 }


### PR DESCRIPTION
# Summary

Issue : #11

プライベートな静的フィールドにアクセスするメソッド, および MonoBrickFirmwareWrapper の各メソッドの動作を, より簡単に(ラムダ式で)入れ替えられるメソッドを作った.

一応, .Net で提供している Action系17種, Func系17種に対応している.

# Usage

```cs
// 引数無し, 戻り値無しのラッパーメソッドを入れ替える
Replacer.ReplaceWrapperMethod(typeof(Foobar), "hoge", () => { });
// 引数無し, 戻り値 int のラッパーメソッドを入れ替える
Replacer.ReplaceWrapperMethod(typeof(Foobar), "hoge", () => 42);
// 引数 string, 戻り値 bool のラッパーメソッドを入れ替える
// 引数は型を明示的に指定しないと, 型推論できない
Replacer.ReplaceWrapperMethod(typeof(Foobar), "hoge", (string message) => true);
// 引数 string, 戻り値 bool のラッパーメソッドを入れ替える
// 引数の型を, 型推論でなく, 型パラメータで指定する方法
Replacer.ReplaceWrapperMethod<string, bool>(typeof(Foobar), "hoge", message => true);
```
