### PR TITLE
Create utility methods to replace instance methods 

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,8 +11,8 @@ coverage:
     project: yes
     patch: yes
     changes: no
-    threshold: 99% # Allow the coverage to drop by X% and posting a success status.
-    target: 1% # Choose minimum coverage ratio the commit must meet to be considered a success status.
+    threshold: 100% # Allow the coverage to drop by X% and posting a success status.
+    target: 0% # Choose minimum coverage ratio the commit must meet to be considered a success status.
 
 parsers:
   gcov:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,9 +10,9 @@ coverage:
   status:
     project: yes
     patch: yes
-    changes: yes
-    threshold: 100% # Allow the coverage to drop by X% and posting a success status.
-    target: 0% # Choose minimum coverage ratio the commit must meet to be considered a success status.
+    changes: no
+    threshold: 99% # Allow the coverage to drop by X% and posting a success status.
+    target: 1% # Choose minimum coverage ratio the commit must meet to be considered a success status.
 
 parsers:
   gcov:

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -84,12 +84,16 @@ namespace MonoBrickFirmwareWrapper.Utilities
 
 		public static void SetPrivateField<T>(this T instance, string fieldName, object value)
 		{
-			throw new NotImplementedException();
+			FieldInfo fieldInfo = typeof(T).GetField(fieldName,
+				BindingFlags.SetField | BindingFlags.NonPublic | BindingFlags.Instance);
+			fieldInfo.SetValue(instance, value);
 		}
 
 		public static object GetPrivateField<T>(this T instance, string fieldName)
 		{
-			throw new NotImplementedException();
+			FieldInfo fieldInfo = typeof(T).GetField(fieldName,
+				BindingFlags.GetField | BindingFlags.NonPublic | BindingFlags.Instance);
+			return fieldInfo.GetValue(instance);
 		}
 
         /// <summary>

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -772,5 +772,175 @@ namespace MonoBrickFirmwareWrapper.Utilities
         {
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
+
+		public static void SetWrapperMethod<TInstance>(this TInstance instance, string methodName, Action action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T>(this TInstance instance, string methodName, Action<T> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2>(this TInstance instance, string methodName, Action<T1, T2> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3>(this TInstance instance, string methodName, Action<T1, T2, T3> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4>(this TInstance instance, string methodName, Action<T1, T2, T3, T4> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action)
+		{
+			instance.SetPrivateField(methodName, action);
+		}
+
+		public static void SetWrapperMethod<TInstance, TResult>(this TInstance instance, string methodName, Func<TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T, TResult>(this TInstance instance, string methodName, Func<T, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, TResult>(this TInstance instance, string methodName, Func<T1, T2, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
+
+		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> function)
+		{
+			instance.SetPrivateField(methodName, function);
+		}
     }
 }

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -82,6 +82,13 @@ namespace MonoBrickFirmwareWrapper.Utilities
             originalFieldValues.Remove(key);
         }
 
+		/// <summary>
+		/// <para>Set a value of a private instance field.</para>
+		/// </summary>
+		/// <typeparam name="T">The type of an instance including a target private instance field.</typeparam>
+		/// <param name="instance">An instance including a target private instance field.</param>
+		/// <param name="fieldName">A target private instance field name.</param>
+		/// <param name="value">A value that you want to set.</param>
 		public static void SetPrivateField<T>(this T instance, string fieldName, object value)
 		{
 			FieldInfo fieldInfo = typeof(T).GetField(fieldName,
@@ -89,6 +96,13 @@ namespace MonoBrickFirmwareWrapper.Utilities
 			fieldInfo.SetValue(instance, value);
 		}
 
+		/// <summary>
+		/// <para>Get a value of a private instance field.</para>
+		/// </summary>
+		/// <typeparam name="T">The type of an instance including a target private instance field.</typeparam>
+		/// <param name="instance">An instance including a target private instance field.</param>
+		/// <param name="fieldName">A target private instance field name.</param>
+		/// <returns>The value of the target private instance field.</returns>
 		public static object GetPrivateField<T>(this T instance, string fieldName)
 		{
 			FieldInfo fieldInfo = typeof(T).GetField(fieldName,

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -82,6 +82,16 @@ namespace MonoBrickFirmwareWrapper.Utilities
             originalFieldValues.Remove(key);
         }
 
+		public static void SetPrivateField<T>(this T instance, string fieldName, object value)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static object GetPrivateField<T>(this T instance, string fieldName)
+		{
+			throw new NotImplementedException();
+		}
+
         /// <summary>
         /// Replace a wrapper method of MonoBrickFirmwareWrapper.
         /// </summary>

--- a/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
+++ b/MonoBrickFirmwareWrapper/Utilities/Replacer.cs
@@ -773,171 +773,698 @@ namespace MonoBrickFirmwareWrapper.Utilities
             ReplacePrivateStaticField(targetClassType, methodName, function);
         }
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance>(this TInstance instance, string methodName, Action action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T>(this TInstance instance, string methodName, Action<T> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2>(this TInstance instance, string methodName, Action<T1, T2> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3>(this TInstance instance, string methodName, Action<T1, T2, T3> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4>(this TInstance instance, string methodName, Action<T1, T2, T3, T4> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T15">The type of the 15th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T15">The type of the 15th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T16">The type of the 16th argument of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="action">An action that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this TInstance instance, string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action)
 		{
 			instance.SetPrivateField(methodName, action);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, TResult>(this TInstance instance, string methodName, Func<TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T, TResult>(this TInstance instance, string methodName, Func<T, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, TResult>(this TInstance instance, string methodName, Func<T1, T2, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T15">The type of the 15th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);
 		}
 
+		/// <summary>
+		/// Set a wrapper method of MonoBrickFirmwareWrapper.
+		/// </summary>
+		/// <typeparam name="TInstance">The type of an instance including a target private instance field.</typeparam>
+		/// <typeparam name="T1">The type of the 1st argument of the wrapper method.</typeparam>
+		/// <typeparam name="T2">The type of the 2nd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T3">The type of the 3rd argument of the wrapper method.</typeparam>
+		/// <typeparam name="T4">The type of the 4th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T5">The type of the 5th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T6">The type of the 6th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T7">The type of the 7th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T8">The type of the 8th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T9">The type of the 9th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T10">The type of the 10th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T11">The type of the 11th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T12">The type of the 12th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T13">The type of the 13th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T14">The type of the 14th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T15">The type of the 15th argument of the wrapper method.</typeparam>
+		/// <typeparam name="T16">The type of the 16th argument of the wrapper method.</typeparam>
+		/// <typeparam name="TResult">The type of the return value of the wrapper method.</typeparam>
+		/// <param name="instance">An instance including a wrapper method.</param>
+		/// <param name="methodName">A wrapper method name.</param>
+		/// <param name="function">A function that you want to set.</param>
 		public static void SetWrapperMethod<TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this TInstance instance, string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> function)
 		{
 			instance.SetPrivateField(methodName, function);


### PR DESCRIPTION
# Summary

Issue : #24

プライベートなインスタンスフィールドにアクセスするメソッド, および MonoBrickFirmwareWrapper の各メソッドの動作を, より簡単に(ラムダ式で)入れ替えられる拡張メソッドを作った.

一応, .Net で提供している Action系17種, Func系17種に対応している.

# Usage

```cs
Foobar instance = new Foobar();
// 引数無し, 戻り値無しのラッパーメソッドを入れ替える
instance.SetWrapperMethod("hoge", () => { });
// 引数無し, 戻り値 int のラッパーメソッドを入れ替える
instance.SetWrapperMethod("hoge", () => 42);
// 引数 string, 戻り値 bool のラッパーメソッドを入れ替える
// 引数は型を明示的に指定しないと, 型推論できない
instance.SetWrapperMethod("hoge", (string message) => true);
// 引数 string, 戻り値 bool のラッパーメソッドを入れ替える
// 引数の型を, 型推論でなく, 型パラメータで指定する方法
instance.SetWrapperMethod<Foobar, string, bool>("hoge", message => true);
```